### PR TITLE
Fix Small Tutorial Issues

### DIFF
--- a/lib/screens/levelscreen.dart
+++ b/lib/screens/levelscreen.dart
@@ -89,9 +89,10 @@ class _LevelScreenState extends State<LevelScreen> {
 
   Widget _getLevel() {
     return _showTutorial
-        ? TutorialScreen(onClose: () {
+        ? TutorialScreen(onClose: ({toHome: false}) {
             setState(() {
               _showTutorial = false;
+              levelIndex = toHome ? -1 : levelIndex;
             });
           })
         : GameScreen(

--- a/lib/screens/tutorialscreen.dart
+++ b/lib/screens/tutorialscreen.dart
@@ -68,7 +68,7 @@ class _TutorialScreenState extends State<TutorialScreen> {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Container(
-                padding: EdgeInsets.only(top: 30),
+                padding: EdgeInsets.only(top: 10),
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.start,
                   children: [

--- a/lib/screens/tutorialscreen.dart
+++ b/lib/screens/tutorialscreen.dart
@@ -108,7 +108,7 @@ class _TutorialScreenState extends State<TutorialScreen> {
                             ? setState(() {
                                 _step -= 1;
                               })
-                            : {},
+                            : widget.onClose(toHome: true),
                         child: Text('Back', style: TextStyle(fontSize: 16))),
                     OutlinedButton(
                         style: OutlinedButton.styleFrom(


### PR DESCRIPTION
## About
This update addresses a couple of small issues on the tutorials screen of the app.
1. There is a layout overflow on the _iPhone SE 2nd gen_ on the second tutorial page.
2. You can't leave the tutorial without completing it, and then clicking the back button in the game screen.

### iPhone SE Tutorial Layout Issue

This was addressed by shrinking the padding at the top of the tutorials.

![iPhone SE 2nd gen tutorials](https://user-images.githubusercontent.com/10450774/120500487-7facd800-c386-11eb-90ad-4ec4815e5b9f.png)

### From Tutorials Back To Levels

This was addressed by making the back button on the first page take you back to the level select screen.

![Screen-Recording-2021-06-02-at-9](https://user-images.githubusercontent.com/10450774/120498629-fb0d8a00-c384-11eb-95c3-a1046320357f.gif)

